### PR TITLE
Text Library: Translations, message templates, and other text utility

### DIFF
--- a/src/main/java/dev/flashlabs/flashlibs/text/MessageService.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/MessageService.java
@@ -58,10 +58,10 @@ public final class MessageService {
      * {@link Locale} applied to the given arguments.
      *
      * @see MessageService#get(String, Locale)
-     * @see MessageTemplate#apply(Object...)
+     * @see MessageTemplate#get(Object...)
      */
     public Text get(String key, Locale locale, Object... args) {
-        return get(key, locale).apply(args);
+        return get(key, locale).get(args);
     }
 
     /**

--- a/src/main/java/dev/flashlabs/flashlibs/text/MessageService.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/MessageService.java
@@ -1,0 +1,86 @@
+package dev.flashlabs.flashlibs.text;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.collect.Maps;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.text.Text;
+
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Provides an interface for retrieving {@link MessageTemplate}s with support
+ * for translations. Messages are provided through a {@link TranslationService}
+ * and cached to maximize reuse of the template.
+ */
+public final class MessageService {
+
+    private final TranslationService translations;
+    private final LoadingCache<Map.Entry<String, Locale>, MessageTemplate> cache;
+
+    private MessageService(TranslationService translations) {
+        this.translations = translations;
+        cache = Caffeine.newBuilder().build(k -> MessageTemplate.of(translations.getString(k.getKey(), k.getValue())));
+    }
+
+    /**
+     * Creates a service delegating to the given {@link TranslationService}.
+     */
+    public static MessageService of(TranslationService translations) {
+        return new MessageService(translations);
+    }
+
+    /**
+     * Creates a service delegating to a {@link TranslationService} using the
+     * given name and path.
+     *
+     * @see TranslationService#of(String, Path)
+     */
+    public static MessageService of(String name, Path path) throws MalformedURLException {
+        return new MessageService(TranslationService.of(name, path));
+    }
+
+    /**
+     * Returns the {@link MessageTemplate} corresponding to the given key and
+     * {@link Locale}. If no such message exists, the key is used.
+     *
+     * @see TranslationService#getString(String, Locale)
+     */
+    public MessageTemplate get(String key, Locale locale) {
+        return cache.get(Maps.immutableEntry(key, locale));
+    }
+
+    /**
+     * Returns a {@link Text} consisting of the template for the given key and
+     * {@link Locale} applied to the given arguments.
+     *
+     * @see MessageService#get(String, Locale)
+     * @see MessageTemplate#apply(Object...)
+     */
+    public Text get(String key, Locale locale, Object... args) {
+        return get(key, locale).apply(args);
+    }
+
+    /**
+     * Sends a message to the given {@link CommandSource} retrieved using the
+     * given key and source's {@link Locale} applied to the given arguments.
+     *
+     * @see MessageService#get(String, Locale, Object...)
+     */
+    public void send(CommandSource source, String key, Object... args) {
+        source.sendMessage(get(key, source.getLocale(), args));
+    }
+
+    /**
+     * Reloads this service, including the backing {@link TranslationService}
+     * and message cache.
+     */
+    public void reload() {
+        translations.reload();
+        cache.invalidateAll();
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/text/MessageTemplate.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/MessageTemplate.java
@@ -52,9 +52,7 @@ public final class MessageTemplate {
             if (placeholder.matches()) {
                 TextTemplate.Arg.Builder builder = TextTemplate.arg(placeholder.group(2));
                 if (placeholder.group(1) != null) {
-                    Text format = TextSerializers.FORMATTING_CODE.deserialize(placeholder.group(1) + "?");
-                    builder.color(format.getColor());
-                    builder.style(format.getStyle());
+                    builder.format(TextSerializers.FORMATTING_CODE.deserialize(placeholder.group(1) + "?").getFormat());
                 }
                 elements.add(builder);
             } else {

--- a/src/main/java/dev/flashlabs/flashlibs/text/MessageTemplate.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/MessageTemplate.java
@@ -1,0 +1,91 @@
+package dev.flashlabs.flashlibs.text;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.TextTemplate;
+import org.spongepowered.api.text.serializer.TextSerializers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a reusable template for messages containing arguments. The
+ * template can be applied to a series of arguments.
+ *
+ * <p>Arguments are defined inside of {@code ${}}, as in string interpolation,
+ * which may be escaped with a leading backslash such as in {@code \${}}. The
+ * brackets contain three parts: the format, a literal {@code @} symbol, and the
+ * argument name. The format is optional {@code &}-style codes, and the name is
+ * any kebab-case string (lowercase and hyphen only). Some examples are {@code
+ * ${@player}}, {@code ${&6&l@player}}, and {@code ${&a@player-location}}.
+ */
+public final class MessageTemplate {
+
+    private static final Pattern ARGUMENT = Pattern.compile("(?<!\\\\)\\$\\{(.*?)}");
+    private static final Pattern PLACEHOLDER = Pattern.compile("((?:&[0-9a-fk-or])*)@([a-z-]+)");
+
+    private final TextTemplate template;
+
+    private MessageTemplate(TextTemplate template) {
+        this.template = template;
+    }
+
+    /**
+     * Creates a template from the given string following the format described
+     * in the class javadoc. If an argument is defined with {@code ${}} but the
+     * contents are invalid, the contents are included directly in the result.
+     *
+     * @see MessageTemplate
+     */
+    public static MessageTemplate of(String string) {
+        List<Object> elements = Lists.newArrayList();
+        Matcher argument = ARGUMENT.matcher(string);
+        int index = 0;
+        while (argument.find()) {
+            if (index < argument.start()) {
+                elements.add(TextSerializers.FORMATTING_CODE.deserialize(string.substring(index, argument.start())));
+            }
+            Matcher placeholder = PLACEHOLDER.matcher(argument.group(1));
+            if (placeholder.matches()) {
+                TextTemplate.Arg.Builder builder = TextTemplate.arg(placeholder.group(2));
+                if (placeholder.group(1) != null) {
+                    Text format = TextSerializers.FORMATTING_CODE.deserialize(placeholder.group(1) + "?");
+                    builder.color(format.getColor());
+                    builder.style(format.getStyle());
+                }
+                elements.add(builder);
+            } else {
+                elements.add(Text.of(argument.group(1)));
+            }
+            index = argument.end();
+        }
+        if (index < string.length()) {
+            elements.add(TextSerializers.FORMATTING_CODE.deserialize(string.substring(index)));
+        }
+        return new MessageTemplate(TextTemplate.of(elements.toArray()));
+    }
+
+    /**
+     * Applies the given arguments to this template using the given map. All
+     * arguments are expected to be defined.
+     */
+    public Text apply(Map<String, Object> args) {
+        return template.apply(args).build();
+    }
+
+    /**
+     * Applies the given arguments to this template by key-value pairs, ignoring
+     * any trailing argument. All arguments are expected to be defined.
+     */
+    public Text apply(Object... args) {
+        Map<String, Object> map = Maps.newHashMap();
+        for (int i = 1; i < args.length; i += 2) {
+            map.put(String.valueOf(args[i - 1]), args[i]);
+        }
+        return apply(map);
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/text/NodeResourceBundle.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/NodeResourceBundle.java
@@ -60,7 +60,7 @@ final class NodeResourceBundle extends ResourceBundle {
      */
     private static final class Control extends ResourceBundle.Control {
 
-        private static final ImmutableList<String> FORMATS = ImmutableList.of("conf", "json", "yaml", "properties");
+        private static final List<String> FORMATS = ImmutableList.of("conf", "json", "yaml", "properties", "class");
 
         @Override
         public List<String> getFormats(String baseName) {
@@ -68,17 +68,19 @@ final class NodeResourceBundle extends ResourceBundle {
         }
 
         @Override
-        public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IOException {
+        public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IllegalAccessException, InstantiationException, IOException {
             URL url = loader.getResource(toResourceName(toBundleName(baseName, locale), format));
             if (url != null) {
-                ConfigurationLoader config;
                 switch (format) {
-                    case "conf": config = HoconConfigurationLoader.builder().setURL(url).build(); break;
-                    case "json": config = GsonConfigurationLoader.builder().setURL(url).build(); break;
-                    case "yaml": config = YAMLConfigurationLoader.builder().setURL(url).build(); break;
-                    default: return newBundle(baseName, locale, "java.properties", loader, reload);
+                    case "conf":
+                        return new NodeResourceBundle(HoconConfigurationLoader.builder().setURL(url).build().load());
+                    case "json":
+                        return new NodeResourceBundle(GsonConfigurationLoader.builder().setURL(url).build().load());
+                    case "yaml":
+                        return new NodeResourceBundle(YAMLConfigurationLoader.builder().setURL(url).build().load());
+                    default:
+                        return super.newBundle(baseName, locale, "java." + format, loader, reload);
                 }
-                return new NodeResourceBundle(config.load());
             }
             return null;
         }

--- a/src/main/java/dev/flashlabs/flashlibs/text/NodeResourceBundle.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/NodeResourceBundle.java
@@ -6,7 +6,6 @@ import com.google.common.collect.Maps;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.gson.GsonConfigurationLoader;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
-import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
 import sun.util.ResourceBundleEnumeration;
 
@@ -56,7 +55,7 @@ final class NodeResourceBundle extends ResourceBundle {
     /**
      * The {@link ResourceBundle.Control} implementation supporting additional
      * formats with Configurate. Hocon (.conf), Json (.json) and Yaml (.yaml)
-     * extensions are supported, as well as the default properties file.
+     * extensions are supported, as well as properties files and classes.
      */
     private static final class Control extends ResourceBundle.Control {
 

--- a/src/main/java/dev/flashlabs/flashlibs/text/NodeResourceBundle.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/NodeResourceBundle.java
@@ -1,0 +1,88 @@
+package dev.flashlabs.flashlibs.text;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.gson.GsonConfigurationLoader;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
+import sun.util.ResourceBundleEnumeration;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+/**
+ * Represents a {@link ResourceBundle} loaded from an {@link ConfigurationNode}.
+ * All values are registered under the path to the node, consisting of all keys
+ * joined with {@code '.'}.
+ */
+final class NodeResourceBundle extends ResourceBundle {
+
+    static final Control CONTROL = new Control();
+
+    private final Map<String, Object> map = Maps.newHashMap();
+
+    private NodeResourceBundle(ConfigurationNode node) {
+        loadValues(node);
+    }
+
+    private void loadValues(ConfigurationNode node) {
+        if (node.hasListChildren()) {
+            node.getChildrenList().forEach(this::loadValues);
+        } else if (node.hasMapChildren()) {
+            node.getChildrenMap().values().forEach(this::loadValues);
+        } else {
+            map.put(Joiner.on('.').join(node.getPath()), node.getValue());
+        }
+    }
+
+    @Override
+    protected Object handleGetObject(String key) {
+        return map.get(key);
+    }
+
+    @Override
+    public Enumeration<String> getKeys() {
+        return new ResourceBundleEnumeration(map.keySet(), parent != null ? parent.getKeys() : null);
+    }
+
+    /**
+     * The {@link ResourceBundle.Control} implementation supporting additional
+     * formats with Configurate. Hocon (.conf), Json (.json) and Yaml (.yaml)
+     * extensions are supported, as well as the default properties file.
+     */
+    private static final class Control extends ResourceBundle.Control {
+
+        private static final ImmutableList<String> FORMATS = ImmutableList.of("conf", "json", "yaml", "properties");
+
+        @Override
+        public List<String> getFormats(String baseName) {
+            return FORMATS;
+        }
+
+        @Override
+        public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload) throws IOException {
+            URL url = loader.getResource(toResourceName(toBundleName(baseName, locale), format));
+            if (url != null) {
+                ConfigurationLoader config;
+                switch (format) {
+                    case "conf": config = HoconConfigurationLoader.builder().setURL(url).build(); break;
+                    case "json": config = GsonConfigurationLoader.builder().setURL(url).build(); break;
+                    case "yaml": config = YAMLConfigurationLoader.builder().setURL(url).build(); break;
+                    default: return newBundle(baseName, locale, "java.properties", loader, reload);
+                }
+                return new NodeResourceBundle(config.load());
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/text/TranslationService.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/TranslationService.java
@@ -25,7 +25,7 @@ public final class TranslationService {
     }
 
     /**
-     * Returns a service loading resource bundles using the given name and class
+     * Creates a service loading resource bundles using the given name and class
      * loader.
      */
     public static TranslationService of(String name, ClassLoader loader) {
@@ -33,7 +33,7 @@ public final class TranslationService {
     }
 
     /**
-     * Returns a service loading resource bundles using the given name and path.
+     * Creates a service loading resource bundles using the given name and path.
      *
      * @throws MalformedURLException If the path's URL could not be created.
      */
@@ -45,6 +45,7 @@ public final class TranslationService {
      * Returns a {@link ResourceBundle} for the given locale.
      *
      * @see ResourceBundle#getBundle(String, Locale)
+     * @throws java.util.MissingResourceException If no resource bundle exists
      */
     public ResourceBundle getBundle(Locale locale) {
         return ResourceBundle.getBundle(name, locale, loader, NodeResourceBundle.CONTROL);

--- a/src/main/java/dev/flashlabs/flashlibs/text/TranslationService.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/TranslationService.java
@@ -1,0 +1,69 @@
+package dev.flashlabs.flashlibs.text;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+/**
+ * Provides an interface for reading translations from {@link ResourceBundle}s
+ * through the provided class loader and name. Translations may be formatted as
+ * property files as well as in Hocon (.conf), Json (.json), and Yaml (.yaml).
+ *
+ * @see ResourceBundle
+ */
+public final class TranslationService {
+
+    private final String name;
+    private final ClassLoader loader;
+
+    private TranslationService(String name, ClassLoader loader) {
+        this.name = name;
+        this.loader = loader;
+    }
+
+    /**
+     * Returns a service loading resource bundles using the given name and class
+     * loader.
+     */
+    public static TranslationService of(String name, ClassLoader loader) {
+        return new TranslationService(name, loader);
+    }
+
+    /**
+     * Returns a service loading resource bundles using the given name and path.
+     *
+     * @throws MalformedURLException If the path's URL could not be created.
+     */
+    public static TranslationService of(String name, Path path) throws MalformedURLException {
+        return new TranslationService(name, new URLClassLoader(new URL[] {path.toUri().toURL()}));
+    }
+
+    /**
+     * Returns a {@link ResourceBundle} for the given locale.
+     *
+     * @see ResourceBundle#getBundle(String, Locale)
+     */
+    public ResourceBundle getBundle(Locale locale) {
+        return ResourceBundle.getBundle(name, locale, loader, NodeResourceBundle.CONTROL);
+    }
+
+    /**
+     * Returns a string value retrieved through the bundle for the given locale.
+     * If the given key is not present, the key itself is returned.
+     */
+    public String getString(String key, Locale locale) {
+        ResourceBundle bundle = getBundle(locale);
+        return bundle.containsKey(key) ? bundle.getObject(key).toString() : key;
+    }
+
+    /**
+     * Reloads the resource bundle cache corresponding to this class loader.
+     */
+    public void reload() {
+        ResourceBundle.clearCache(loader);
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/text/package-info.java
+++ b/src/main/java/dev/flashlabs/flashlibs/text/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * The text library provides resources for loading translations, working with
+ * message templates, and managing messages used throughout a plugin.
+ */
+@NonnullByDefault
+@Library(id = "text", version = "0.0.0")
+package dev.flashlabs.flashlibs.text;
+
+import dev.flashlabs.flashlibs.Library;
+import org.spongepowered.api.util.annotation.NonnullByDefault;

--- a/src/test/java/dev/flashlabs/flashlibs/text/TranslationServiceTest.java
+++ b/src/test/java/dev/flashlabs/flashlibs/text/TranslationServiceTest.java
@@ -1,0 +1,33 @@
+package dev.flashlabs.flashlibs.text;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.spongepowered.api.text.translation.locale.Locales;
+
+import java.util.Locale;
+import java.util.stream.Stream;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+final class TranslationServiceTest {
+
+    private static final TranslationService SERVICE = TranslationService.of("messages.messages", ClassLoader.getSystemClassLoader());
+
+    private static Stream<Arguments> test() {
+        return Stream.of(
+                Arguments.arguments("greeting.hello", Locales.DEFAULT, "Hello there!"),
+                Arguments.arguments("greeting.hello", Locales.EN_US, "Hello there!"),
+                Arguments.arguments("greeting.hello", Locales.EN_PT, "Ahoy matey!"),
+                Arguments.arguments("absent-key", Locales.DEFAULT, "absent-key")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void test(String key, Locale locale, String expected) {
+        Assertions.assertEquals(expected, SERVICE.getString(key, locale));
+    }
+
+}

--- a/src/test/resources/messages/messages.properties
+++ b/src/test/resources/messages/messages.properties
@@ -1,0 +1,1 @@
+greeting.hello = Hello there!

--- a/src/test/resources/messages/messages_en_PT.conf
+++ b/src/test/resources/messages/messages_en_PT.conf
@@ -1,0 +1,1 @@
+greeting.hello = "Ahoy matey!"


### PR DESCRIPTION
# Description

This PR introduces the Text library, which provides a number of text related utilities, most notably the ability to load translations and work with message templates for placeholders.

## Progress

 - [X] ResourceBundle translations
 - [X] Hocon support for translations (also Json and Yaml)
 - [X] Message templates for basic arguments
 - [ ] Conditional templates for grammar (a/an, singular/plural, etc)
 - [ ] Additional placeholder support?

## Arguments

The format for arguments is worth discussing up front because is the most user-centric decision in this PR. The current approach is to use `${}` like string interpolation and allow `\${}` for escapes. This is unlikely to conflict with other text and is a rather common standard in programming languages. Inside the braces, an argument consists of a format (`&`-style codes like `&a&l`), the literal `@` symbol (to specify 'argument'), and the name of the argument (`kebab-case`, aka `lowercase-hypen`).

Examples of arguments:
 - `${@player}`
 - `${&6&l@player}`
 - `${&a@player-location}`

> Formats inside the argument do not 'bleed' into the remainder of the text.

## Placeholders

Supporting placeholders is also worth considering so contextual information can be used in the output. This could be as simple as getting the location of the player rather than using a separate argument, or could become as complex as supporting singular/plural selections or even passing arguments to pre-defined functions. Any system like this would need to be incredibly well-designed and support registering additional placeholders, which would likely need to be namespaced as well. Placeholders would have to have a unique syntax from arguments to avoid conflicts or arbitrary name restrictions, such as `#player`.

## TranslationService

The `TranslationService` class is responsible for providing a [`ResourceBundle`](https://docs.oracle.com/javase/8/docs/api/java/util/ResourceBundle.html) and contains a `ClassLoader` and name. Factory methods exist for using a provided class loader or a `URLClassLoader` retrieved from a `Path`. The service can be used to retrieve a bundle for a given `Locale` as well as a `String` value for a given key.

Example usage:

```java
//creates a TranslationService loading messages from the translations config folder
TranslationService translations = TranslationService.of("messages", pluginDir.resolve("translations"));

//gets a message for greetings.hello as a String using a player's locale
String message = translations.getString("greetings.hello", player.getLocale());
```

### Implementation

The majority of the implementation is handled through the `ResourceBundle` class. In order to load files using Hocon, an internal `NodeResourceBundle` class implements a resource bundle based on `ConfigurationNode`s. The `Control` class handles lookups based on allowed formats, and delegates to the superclass for properties files. Note that caching is performed automatically on `ResourceBundle`s.

Hocon support is included because the string format in properties file is significantly different from Hocon or other standard configuration formats. Values are not surrounded in quotes and must escape things like newlines, colons, and equal signs. Allowing Hocon to be used instead is more consistent for the user and less likely to result in unexpected errors.

## MessageService

### Implementation

The implementations simply links between the `TranslationService` and `MessageTemplate` classes, however also maintains a cache for the deserialized templates. Whether this cache is beneficial or not is worth consideration.

## MessageTemplate

The `MessageTemplate` class is what implements the above placeholder system. It contains a factory method for creating a template from a string and two methods for applying arguments; one using a map and the other varargs.

### Implementation

Internally, `MessageTemplate`s are implemented using Sponge's `TextTemplate` class. This class is known to have a lot of issues, but the majority of these are not present here due to the way it is constructed. The use of `TextTemplate` should be considered an implementation detail in case a full placeholder system is eventually supported.

Notably, the use of Sponge's `TextSerializers.FORMATTING_CODE` prevents this class from being tested without a server instance. In combination with the regex's used to recognize arguments, some degree of manual parsing may be worth considering.

## Feedback

Being the first PR, I figure it's worth noting a couple things about libraries in FlashLibs as well as related PR information.

Libraries are *not* indented to be complete solutions - these should be ~80% solutions that allows developers to extend that final 20% for their particular use case. A common standard should certainly exist, but there's no need to be restrictive where it is not required.

Additionally, I encourage feedback on PRs - especially the library ones which add entirely new features to FlashLibs. Writing a library is no easy task, and the trial and error that comes from feedback and revision of the API ultimately results in a better product. Though we absolutely intend to use these for ourselves, the goal is to build a community library to help make Sponge development easier overall. So please, take the time to provide feedback on the API as you might be using it one day!

Various feedback topics:
 - API of the library
 - Implementation decisions
 - Current functionality
 - Use of placeholders and context system
 - Other potential features
 - Related questions/comments/concerns