### PR TITLE
Command library: Initialize and register commands

### DIFF
--- a/src/main/java/dev/flashlabs/flashlibs/command/Command.java
+++ b/src/main/java/dev/flashlabs/flashlibs/command/Command.java
@@ -2,16 +2,18 @@ package dev.flashlabs.flashlibs.command;
 
 import com.google.common.collect.ImmutableList;
 import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.CommandMapping;
 import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.text.Text;
 
+import java.util.Optional;
+
 /**
  * Represents a command that is registered with Sponge. Commands are created
- * through the {@link CommandService} by injecting into a constructor taking a
- * {@link Command.Builder} parameter. Commands are registered automatically upon
- * initialization.
+ * through the {@link CommandService} by injecting into the constructor.
+ * Commands are registered automatically upon initialization.
  *
  * @see CommandSpec
  */
@@ -19,15 +21,19 @@ public abstract class Command implements CommandExecutor {
 
     private final CommandSpec spec;
     private final ImmutableList<String> aliases;
+    final Optional<CommandMapping> mapping;
 
     /**
      * Initializes this command with the values set in the builder and registers
-     * it to Sponge.
+     * it to Sponge. Instances are initialized through constructor injection, so
+     * the subclass must provide a constructor matching this signature.
+     *
+     * @see CommandService#get(Class)
      */
     protected Command(Builder builder) {
         spec = builder.spec.build();
         aliases = builder.aliases.build();
-        Sponge.getCommandManager().register(builder.service.container, spec, aliases.stream()
+        mapping = Sponge.getCommandManager().register(builder.service.container, spec, aliases.stream()
                 .filter(a -> a.startsWith("/"))
                 .map(a -> a.substring(1))
                 .toArray(String[]::new));
@@ -37,7 +43,7 @@ public abstract class Command implements CommandExecutor {
      * A builder for commands that creates the internal {@link CommandSpec} and
      * aliases used for registration with Sponge.
      */
-    protected static class Builder {
+    protected static final class Builder {
 
         private final CommandService service;
         private final CommandSpec.Builder spec = CommandSpec.builder();

--- a/src/main/java/dev/flashlabs/flashlibs/command/Command.java
+++ b/src/main/java/dev/flashlabs/flashlibs/command/Command.java
@@ -1,0 +1,100 @@
+package dev.flashlabs.flashlibs.command;
+
+import com.google.common.collect.ImmutableList;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.text.Text;
+
+/**
+ * Represents a command that is registered with Sponge. Commands are created
+ * through the {@link CommandService} by injecting into a constructor taking a
+ * {@link Command.Builder} parameter. Commands are registered automatically upon
+ * initialization.
+ *
+ * @see CommandSpec
+ */
+public abstract class Command implements CommandExecutor {
+
+    private final CommandSpec spec;
+    private final ImmutableList<String> aliases;
+
+    /**
+     * Initializes this command with the values set in the builder and registers
+     * it to Sponge.
+     */
+    protected Command(Builder builder) {
+        spec = builder.spec.build();
+        aliases = builder.aliases.build();
+        Sponge.getCommandManager().register(builder.service.container, spec, aliases.stream()
+                .filter(a -> a.startsWith("/"))
+                .map(a -> a.substring(1))
+                .toArray(String[]::new));
+    }
+
+    /**
+     * A builder for commands that creates the internal {@link CommandSpec} and
+     * aliases used for registration with Sponge.
+     */
+    protected static class Builder {
+
+        private final CommandService service;
+        private final CommandSpec.Builder spec = CommandSpec.builder();
+        private final ImmutableList.Builder<String> aliases = ImmutableList.builder();
+
+        Builder(CommandService service) {
+            this.service = service;
+        }
+
+        /**
+         * Adds the given aliases to this command. Aliases that start with
+         * {@code '/'} will be registered with Sponge; all others are used as
+         * aliases for child commands.
+         */
+        public Builder aliases(String... aliases) {
+            this.aliases.add(aliases);
+            return this;
+        }
+
+        /**
+         * Sets the description for this command.
+         */
+        public Builder description(Text description) {
+            spec.description(description);
+            return this;
+        }
+
+        /**
+         * Sets the permission for this command.
+         */
+        public Builder permission(String permission) {
+            spec.permission(permission);
+            return this;
+        }
+
+        /**
+         * Adds the given commands as children to this command. Each child is
+         * provided by the {@link CommandService}.
+         */
+        public Builder children(Class<? extends Command>... children) {
+            for (Class<? extends Command> child : children) {
+                Command command = service.get(child);
+                spec.child(command.spec, command.aliases.stream()
+                        .filter(s -> !s.startsWith("/"))
+                        .toArray(String[]::new));
+            }
+            return this;
+        }
+
+        /**
+         * Sets the elements used for parsing arguments.
+         */
+        public Builder elements(CommandElement... elements) {
+            spec.arguments(elements);
+            return this;
+        }
+
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/command/CommandService.java
+++ b/src/main/java/dev/flashlabs/flashlibs/command/CommandService.java
@@ -1,0 +1,65 @@
+package dev.flashlabs.flashlibs.command;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.plugin.PluginContainer;
+
+import java.lang.reflect.Constructor;
+
+/**
+ * Provides an interface for initializing and registering commands for a plugin.
+ */
+public final class CommandService {
+
+    final PluginContainer container;
+    private final LoadingCache<Class<? extends Command>, Command> cache = Caffeine.newBuilder().build(c -> {
+        Constructor<? extends Command> constructor = c.getDeclaredConstructor(Command.Builder.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(new Command.Builder(this));
+    });
+
+    private CommandService(PluginContainer container) {
+        this.container = container;
+    }
+
+    /**
+     * Creates a service managing commands for the given plugin. This service
+     * presumes it is the controller for all commands registered by the plugin.
+     */
+    public static CommandService of(PluginContainer container) {
+        return new CommandService(container);
+    }
+
+    /**
+     * Returns the instance corresponding to the given class or creates one as
+     * needed. Instances are created through constructor injection.
+     *
+     * @throws java.util.concurrent.CompletionException If the class does not
+     *         have a valid constructor or could not be instantiated
+     * @see Command#Command(Command.Builder)
+     */
+    public Command get(Class<? extends Command> clazz) {
+        return cache.get(clazz);
+    }
+
+    /**
+     * Registers commands for the given classes to Sponge, as well as any child
+     * commands with primary aliases.
+     */
+    public void register(Class<? extends Command>... classes) {
+        for (Class<? extends Command> clazz : classes) {
+            get(clazz);
+        }
+    }
+
+    /**
+     * Unregisters all commands owned by the backing plugin and invalidates any
+     * instances loaded by this service.
+     */
+    public void unregister() {
+        Sponge.getCommandManager().getOwnedBy(container).forEach(Sponge.getCommandManager()::removeMapping);
+        cache.invalidateAll();
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/command/package-info.java
+++ b/src/main/java/dev/flashlabs/flashlibs/command/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * The command library provides a service for creating and registering commands
+ * in hierarchies, as well as other common actions for commands.
+ */
+@NonnullByDefault
+@Library(id = "command", version = "0.0.0")
+package dev.flashlabs.flashlibs.command;
+
+import dev.flashlabs.flashlibs.Library;
+import org.spongepowered.api.util.annotation.NonnullByDefault;


### PR DESCRIPTION
## Description

This PR introduces the Command library, which provides systems for initializing and registering commands.

### Features

 - [X] Automatic registration of initialized commands
 - [X] Primary aliases for subcommands
 - [X] Easy definition of subcommands (via injection)
 - [X] Reload/unregister commands
 - [ ] Custom usage and extended description
 - [ ] Dynamic subcommand registration
 - [ ] Source specific description/help/etc (permission, translation, etc)
 - [ ] Specify custom aliases for subcommands

### CommandService

The `CommandService` handles the initialization and registration of commands using injection and serves as a provider for command instances. In general, this can be done entirely through the `register` method.

#### Examples

```java
CommandService commands = CommandService.of(container);

commands.register(Base.class); //where Base is a subclass of Command

commands.unregister();
```

#### Implementation

The service is primarily implemented through the use of a Caffeine `LoadingCache` and uses reflection to create a new instance of the class if one does not exist. Additionally, because the class is intended to manage all commands for a plugin the `unregister` method will include commands not explicitly registered through the service. This behavior should not be relied upon.

### Command

The `Command` class is the base class for defining commands. In addition to being a normal `CommandExecutor`, the class provides a constructor taking a `Command.Builder` which is used to define things such as aliases, the permission, and subcommands. These commands are registered to Sponge upon initialization using any aliases beginning with `/`.

#### Examples

```java
public class Base extends Command {

    private Base(Command.Builder builder) {
        super(builder.aliases("/cmddemo", "/cd")
                .description("The base command for this demo")
                .permission("cmddemo.command.base")
                .children(Child1.class, Child2.class, Child3.class));
    }

    public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
        src.sendMessage(Text.of("Demo command"));
        return CommandResult.success();
    }

}
```