### PR TITLE
 Database library: Connect and interact with databases

### DIFF
--- a/src/main/java/dev/flashlabs/flashlibs/database/Connection.java
+++ b/src/main/java/dev/flashlabs/flashlibs/database/Connection.java
@@ -1,0 +1,59 @@
+package dev.flashlabs.flashlibs.database;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Represents a connection to the database. This class implements
+ * {@link AutoCloseable}, which can be used with try-with-resources.
+ */
+public class Connection implements AutoCloseable {
+    
+    protected final java.sql.Connection connection;
+
+    Connection(java.sql.Connection connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * Creates a reusable statement prepared by the connection that allows for
+     * parameters to be defined.
+     *
+     * @throws SQLException If a database error occurs
+     * @see java.sql.Connection#prepareStatement(String)
+     */
+    public final Statement getStatement(String sql) throws SQLException {
+        return new Statement(connection.prepareStatement(sql));
+    }
+
+    /**
+     * Executes an SQL statement with the given arguments as a database
+     * modification, which does not return any results.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    public final void update(String sql, Object... args) throws SQLException {
+        getStatement(sql).setParams(args).update();
+    }
+
+    /**
+     * Executes an SQL statement with the given arguments as a database query
+     * and returns the retrieved results.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    public final ResultSet query(String sql, Object... args) throws SQLException {
+        return getStatement(sql).setParams(args).query();
+    }
+
+    /**
+     * Closes this connection.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    @Override
+    public void close() throws SQLException {
+        connection.close();
+    }
+    
+}

--- a/src/main/java/dev/flashlabs/flashlibs/database/DatabaseService.java
+++ b/src/main/java/dev/flashlabs/flashlibs/database/DatabaseService.java
@@ -1,0 +1,97 @@
+package dev.flashlabs.flashlibs.database;
+
+import com.sun.rowset.CachedRowSetImpl;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.service.sql.SqlService;
+
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import javax.sql.rowset.CachedRowSet;
+
+/**
+ * Provides a interface for interacting with a database using a
+ * {@link DataSource}, which can also be retrieved using a JDBC string. This
+ * service provides methods for directly executing single SQL statements and
+ * methods for obtaining connections for multiple SQL statements or managing
+ * database transactions.
+ */
+public final class DatabaseService {
+
+    private final DataSource source;
+
+    private DatabaseService(DataSource source) {
+        this.source = source;
+    }
+
+    /**
+     * Creates a service backed by the given {@link DataSource}.
+     */
+    public static DatabaseService of(DataSource source) {
+        return new DatabaseService(source);
+    }
+
+    /**
+     * Creates a service from the given JDBC string using Sponge's provided
+     * {@link SqlService}.
+     *
+     * @throws SQLException If database connection could not be established
+     * @see SqlService#getDataSource(String)
+     */
+    public static DatabaseService of(String jdbc) throws SQLException {
+        return new DatabaseService(Sponge.getServiceManager().provideUnchecked(SqlService.class).getDataSource(jdbc));
+    }
+
+    public DataSource getSource() {
+        return source;
+    }
+
+    /**
+     * Returns a reusable connection to the database.
+     *
+     * @throws SQLException If a database access error occurs
+     */
+    public Connection getConnection() throws SQLException {
+        return new Connection(source.getConnection());
+    }
+
+    /**
+     * Returns a reusable connection to the database that is designed for
+     * managing database transactions.
+     *
+     * @throws SQLException If a database access error occurs
+     */
+    public Transaction getTransaction() throws SQLException {
+        return new Transaction(source.getConnection());
+    }
+
+    /**
+     * Opens a unique connection to execute an SQL statement with the given
+     * arguments as a database modification, which does not return any results.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    public void update(String sql, Object... args) throws SQLException {
+        try (Connection connection = getConnection()) {
+            connection.update(sql, args);
+        }
+    }
+
+    /**
+     * Opens a unique connection to execute an SQL statement with the given
+     * arguments as a database query and returns the retrieved results. The
+     * results are cached in memory independent of a connection, since the
+     * connection is discarded.
+     *
+     * @throws SQLException If a database error occurs
+     * @see CachedRowSet
+     * @see java.sql.ResultSet
+     */
+    public CachedRowSet query(String sql, Object... args) throws SQLException {
+        try (Connection connection = getConnection()) {
+            CachedRowSetImpl cached = new CachedRowSetImpl();
+            cached.populate(connection.query(sql, args));
+            return cached;
+        }
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/database/Statement.java
+++ b/src/main/java/dev/flashlabs/flashlibs/database/Statement.java
@@ -1,0 +1,53 @@
+package dev.flashlabs.flashlibs.database;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Represents a {@link PreparedStatement}, which contains a precompiled SQL
+ * statement. Statements can be provided parameters and reused.
+ */
+public final class Statement {
+    
+    private final PreparedStatement statement;
+
+    Statement(PreparedStatement statement) {
+        this.statement = statement;
+    }
+
+    /**
+     * Sets the parameters for this statement using the provided arguments.
+     * Arguments are set in the same order as defined in the original statement.
+     *
+     * @throws SQLException If a database error occurs
+     * @see PreparedStatement#setObject(int, Object) 
+     */
+    public Statement setParams(Object... args) throws SQLException {
+        for (int i = 0; i < args.length; i++) {
+            statement.setObject(i + 1, args[i]);
+        }
+        return this;
+    }
+
+    /**
+     * Executes this statement as a database modification, which does not return
+     * any results.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    public void update() throws SQLException {
+        statement.executeUpdate();
+    }
+
+    /**
+     * Executes this statement as a database query and returns the retrieved
+     * results.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    public ResultSet query() throws SQLException {
+        return statement.executeQuery();
+    }
+    
+}

--- a/src/main/java/dev/flashlabs/flashlibs/database/Transaction.java
+++ b/src/main/java/dev/flashlabs/flashlibs/database/Transaction.java
@@ -1,0 +1,40 @@
+package dev.flashlabs.flashlibs.database;
+
+import java.sql.SQLException;
+
+/**
+ * Represents a {@link Connection} for database transactions. This transaction
+ * can be committed multiple times and will automatically rollback any
+ * uncommitted statements when auto closed (such as on an exception).
+ *
+ * @see java.sql.Connection#setAutoCommit(boolean)
+ */
+public final class Transaction extends Connection {
+
+    Transaction(java.sql.Connection connection) throws SQLException {
+        super(connection);
+        connection.setAutoCommit(false);
+    }
+
+    /**
+     * Commits any statements executed since the previous commit.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    public void commit() throws SQLException {
+        connection.commit();
+    }
+
+    /**
+     * Closes this transaction and rolls back any uncommitted SQL statements.
+     *
+     * @throws SQLException If a database error occurs
+     */
+    @Override
+    public void close() throws SQLException {
+        connection.rollback();
+        connection.setAutoCommit(true);
+        connection.close();
+    }
+
+}

--- a/src/main/java/dev/flashlabs/flashlibs/database/package-info.java
+++ b/src/main/java/dev/flashlabs/flashlibs/database/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * The database library provides a service for interacting with databases such
+ * as obtaining connections, executing statements, and managing transactions.
+ */
+@NonnullByDefault
+@Library(id = "database", version = "0.0.0")
+package dev.flashlabs.flashlibs.database;
+
+import dev.flashlabs.flashlibs.Library;
+import org.spongepowered.api.util.annotation.NonnullByDefault;


### PR DESCRIPTION
## Description

This PR introduces the database library, which provides a service for connecting and interacting with databases. This service currently tested against and supports the following three databases: H2, SQLite, and MySQL.

## Features

 - [X] Can use H2, SQLite, and MySQL
 - [X] Transactions, including rollbacks
 - [X] Custom connections/prepared statements
 - [X] Varargs for database statements
 - [ ] Use java.sql.Connection in implementation of Connection
 - [ ] Specify argument types in database statement parameters
 - [ ] Completable futures variance for update and query

### DatabaseService

The `DatabaseService` class provides the `DataSource` that is either obtained directly from the User or is created using a given JDBC string. This service also provides a custom `Connection` class to create database connections, so long as a connection is available in the resource pool, and a custom `PreparedStatement` class to execute any database statements. Both `Connection` and `Statement` are reusable resources that can be created by the User or will be created by the service when called by the single use execute/query method.

#### Examples:
```java
DatabaseService database = DatabaseService.of(“jdbc:h2:config/plugin/database.h2”);

database.update("UPDATE `Users` SET name=? WHERE uuid=?", player.getName(), player.getUniqueId());

ResultSet result = database.query("SELECT * FROM Users");
```

#### Implementation

`DatabaseService` provides custom classes made for handling Connections (or [Transactions](#transaction), see below) and Statements. Connections are implemented with AutoCloseable in mind so they can be used in a try-with-resources statement but be closed automatically upon completion of that object. Statements, once created, will take in all arguments into the database statement and will be automatically execute or query that statement. There are also single use query and execute methods that automatically handle opening and closing connections should the User just want to execute the statement without have to create the Connection or Statement themselves. 

One thing to majorily note is in the `Connection#query(String, Object…)` method, which returns a `CacheRowSet` and not a `ResultSet`. This is primarily due to the fact that you need an active and open connection and prepared statement to work with a `ResultSet`, otherwise if either of the previous close, you lose the data and cannot work with the results. `CachedRowSet`, on the other hand, is not dependent on an active or open connection and can hold database information in memory. It is accessed similarly to a `ResultSet`, making it perfect to return results and allows us to not leaking memory by closing the other objects. 



### Transaction

The `Transaction` is a connection class that is setup with database transactions in mind. This class can be called in a try-with-resources statement, which will automatically handle closing the connection and rolling back any uncommitted statements to the database.

#### Examples:

```java
try (Transaction transaction = database.getTransaction()){

  database.update("INSERT INTO `playerdata` (PlayerUUID, PlayerName) VALUES (?,?) 
  ON DUPLICATE KEY UPDATE PlayerName=?", player.getUniqueId(), player.getName(), player.getName());

  database.update("UPDATE `playerdata` SET PlayerTime=? WHERE PlayerUUID=?", 
  playerTimePlayed, player.getUniqueId());

  transaction.commit();
}
```

#### Implementation

`Transaction` will automatically handle turning off autocommit, which puts the database into transaction mode and allows the User to choose when to commit their statements via the commit method. Users can choose to call commit after each database statement or after multiple statements have executed successfully. Should there be an exception at any point, or the User is finished with the transaction, the close needs to be called and auto commit will be turned back to true to set the database back into single-statement mode as well as close out the connection and roll back uncommitted statements.